### PR TITLE
add option to delete already converted files, if their source files dont exist anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ optional arguments:
                         path to source directory
   -t TARGET, --target TARGET
                         path to target directory
+  -del, --del_converted
+                        delete converted opus files, which source files do not
+                        exist anymore
   --opusenc-args OPUSENC_ARGS
                         arguments to pass to opusenc (see
                         https://mf4.xiph.org/jenkins/view/opus/job/opus-

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ optional arguments:
                         path to source directory
   -t TARGET, --target TARGET
                         path to target directory
-  -del, --del_converted
+  -thr COUNT, --threads COUNT
+                        thread count for parallel processing
+  -del, --del-removed
                         delete converted opus files, which source files do not
                         exist anymore
   --opusenc-args OPUSENC_ARGS

--- a/tests/test_to_opus.py
+++ b/tests/test_to_opus.py
@@ -51,7 +51,9 @@ class TestToOpus(unittest.TestCase):
             target=target_dir,
             verbose=True,
             opusenc_args=[],
-            database=None
+            database=None,
+            del_removed=None,
+            threads=8
         ))
 
         self.assertEqual(0, base_diff.main(source_dir, target_dir))
@@ -62,7 +64,9 @@ class TestToOpus(unittest.TestCase):
             target=target_dir,
             verbose=True,
             opusenc_args=[],
-            database=db_empty_tmp
+            database=db_empty_tmp,
+            del_removed=None,
+            threads=8
         ))
 
         self.assertEqual(0, base_diff.main(source_dir, target_dir))
@@ -73,7 +77,9 @@ class TestToOpus(unittest.TestCase):
             target=target_dir,
             verbose=True,
             opusenc_args=[],
-            database=db_full_tmp
+            database=db_full_tmp,
+            del_removed=None,
+            threads=8
         ))
 
         self.assertEqual(0, base_diff.main(source_dir, target_dir))
@@ -84,7 +90,9 @@ class TestToOpus(unittest.TestCase):
             target=target_dir,
             verbose=True,
             opusenc_args=[],
-            database=db_nonexistent
+            database=db_nonexistent,
+            del_removed=None,
+            threads=8
         ))
 
         self.assertEqual(0, base_diff.main(source_dir, target_dir))

--- a/to_opus.py
+++ b/to_opus.py
@@ -48,7 +48,7 @@ class Migrator(object):
         self.db = db
 
         if del_removed:
-            self.delete_converted()
+            self.delete_removed()
 
         self.extensions_to_action = {
             # Convert files with these extensions to .opus
@@ -109,7 +109,7 @@ class Migrator(object):
         self.pool.close()
         self.pool.join()
 
-    def delete_converted(self):
+    def delete_removed(self):
         self.logger.info('checking source files that do not exist anymore')
         for root, _, files in os.walk(self.target_dir):
             for file in files:


### PR DESCRIPTION
If you rename (or delete) a source file, it will get converted again. The old conversion doesn't get deleted though.

This included a new option --del_converted. It removes converted files (and possibly its db entry), which don't have a matching source files.